### PR TITLE
Switch to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Example:
 
     logging.getLogger('').addHandler(splunk)
 
-    logging.info('hello!')
+    logging.warning('hello!')
 
 I would recommend using a JSON formatter with this to receive your logs in JSON format.
 Here is an open source one: https://github.com/madzak/python-json-logger
@@ -57,12 +57,12 @@ Here is an example dictionary config:
                 'level': 'DEBUG',
                 'class': 'splunk_handler.SplunkHandler',
                 'formatter': 'json',
-                'filters': ['splunk_filter'],
                 'host': SPLUNK_HOST,
                 'port': SPLUNK_PORT,
                 'username': SPLUNK_USERNAME,
                 'password': SPLUNK_PASSWORD,
-                'index': SPLUNK_INDEX
+                'index': SPLUNK_INDEX,
+                'sourcetype': 'json'
             },
             'console': {
                 'level': 'DEBUG',

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Example:
         username='username',
         password='password',
         index='main'
+        #hostname='hostname', # manually set a hostname parameter, defaults to socket.gethostname()
+        #source='source', # manually set a source, defaults to the log record.pathname
+        #sourcetype='sourcetype', # manually set a sourcetype, defaults to 'text'
+        #verify=True # turn SSL verification on or off, defaults to True
     )
 
     logging.getLogger('').addHandler(splunk)

--- a/README.md
+++ b/README.md
@@ -74,20 +74,13 @@ Here is an example dictionary config:
             '': {
                 'handlers': ['console', 'splunk'],
                 'level': 'DEBUG'
-            },
-            'requests': {
-              'propagate': False
             }
         }
     }
 
 Then, do `logging.config.dictConfig(LOGGING)` to configure your logging.
 
-Couple notes about this:
-
-* It is important to include the configuration for the requests library logger
-so that you do not cause a recursive loop of log entries to be sent to Splunk.
-* I included a configuration for the JSON formatter mentioned above.
+Note: I included a configuration for the JSON formatter mentioned above.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,6 @@ Here is an example dictionary config:
                 'format': '%(asctime)s %(created)f %(exc_info)s %(filename)s %(funcName)s %(levelname)s %(levelno)s %(lineno)d %(module)s %(message)s %(pathname)s %(process)s %(processName)s %(relativeCreated)d %(thread)s %(threadName)s'
             }
         },
-        'filters': {
-            'splunk_filter': {
-                '()': 'splunk_handler.SplunkFilter'
-            }
-        },
         'handlers': {
             'splunk': {
                 'level': 'DEBUG',
@@ -79,6 +74,9 @@ Here is an example dictionary config:
             '': {
                 'handlers': ['console', 'splunk'],
                 'level': 'DEBUG'
+            },
+            'requests': {
+              'propagate': False
             }
         }
     }
@@ -87,11 +85,8 @@ Then, do `logging.config.dictConfig(LOGGING)` to configure your logging.
 
 Couple notes about this:
 
-* I have included a configuration for the SplunkFilter class that is located in this
-package. It is necessary if you want to forward debug logs to the Splunk, because
-Splunk's SDK has debug logging that logs directly to the root logger. There is an
-[open issue](https://github.com/splunk/splunk-sdk-python/pull/94) but this filter is
-required until that gets merged and a new version of the SDK is released.
+* It is important to include the configuration for the requests library logger
+so that you do not cause a recursive loop of log entries to be sent to Splunk.
 * I included a configuration for the JSON formatter mentioned above.
 
 ## Contributing

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name = 'splunk_handler',
-    version = '1.0.0',
+    version = '1.1.0',
     license = 'MIT License',
     description = 'A Python logging handler that sends your logs to Splunk',
     long_description = open('README.md').read(),
@@ -10,7 +10,7 @@ setup(
     author_email = 'ztaylor234@gmail.com',
     url = 'https://github.com/zach-taylor/splunk_handler',
     packages = ['splunk_handler'],
-    install_requires = ['splunk-sdk==1.2.3'],
+    install_requires = ['requests==2.5.1'],
     classifiers = [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -22,6 +22,9 @@ class SplunkHandler(logging.Handler):
         self.password = password
         self.index = index
 
+        requests_log = logging.getLogger('requests')
+        requests_log.propagate = False
+
     def emit(self, record):
 
         thread = Thread(target=self._async_emit, args=(record, ))

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -12,7 +12,7 @@ class SplunkHandler(logging.Handler):
     A logging handler to send events to a Splunk Enterprise instance
     """
 
-    def __init__(self, host, port, username, password, index, hostname=None, source=None, sourcetype='python', verify=True):
+    def __init__(self, host, port, username, password, index, hostname=None, source=None, sourcetype='text', verify=True):
 
         logging.Handler.__init__(self)
 

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -12,7 +12,8 @@ class SplunkHandler(logging.Handler):
     A logging handler to send events to a Splunk Enterprise instance
     """
 
-    def __init__(self, host, port, username, password, index, hostname=None, source=None, sourcetype='text', verify=True):
+    def __init__(self, host, port, username, password, index,
+                 hostname=None, source=None, sourcetype='text', verify=True):
 
         logging.Handler.__init__(self)
 

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -12,7 +12,7 @@ class SplunkHandler(logging.Handler):
     A logging handler to send events to a Splunk Enterprise instance
     """
 
-    def __init__(self, host, port, username, password, index, hostname=None, source=None, sourcetype='json'):
+    def __init__(self, host, port, username, password, index, hostname=None, source=None, sourcetype='python', verify=True):
 
         logging.Handler.__init__(self)
 
@@ -23,6 +23,7 @@ class SplunkHandler(logging.Handler):
         self.index = index
         self.source = source
         self.sourcetype = sourcetype
+        self.verify = verify
 
         if hostname is None:
             self.hostname = socket.gethostname()
@@ -62,7 +63,8 @@ class SplunkHandler(logging.Handler):
                 url,
                 auth=auth,
                 data=payload,
-                params=params
+                params=params,
+                verify=self.verify
             )
 
             r.close()

--- a/tests/test_splunk_handler.py
+++ b/tests/test_splunk_handler.py
@@ -1,0 +1,33 @@
+import logging
+import unittest
+
+from splunk_handler import SplunkHandler
+
+SPLUNK_HOST = 'splunk.example.com'
+SPLUNK_PORT = '8089'
+SPLUNK_USERNAME = 'admin'
+SPLUNK_PASSWORD = 'password'
+SPLUNK_INDEX = 'main'
+
+RECEIVER_URL = 'https://%s:%s/services/receivers/simple' % (SPLUNK_HOST, SPLUNK_PORT)
+
+class TestSplunkHandler(unittest.TestCase):
+    def setUp(self):
+        self.splunk = SplunkHandler(
+            host=SPLUNK_HOST,
+            port=SPLUNK_PORT,
+            username=SPLUNK_USERNAME,
+            password=SPLUNK_PASSWORD,
+            index=SPLUNK_INDEX
+        )
+
+    def test_init(self):
+        self.assertIsNotNone(self.splunk)
+        self.assertIsInstance(self.splunk, SplunkHandler)
+        self.assertIsInstance(self.splunk, logging.Handler)
+        self.assertEqual(self.splunk.host, SPLUNK_HOST)
+        self.assertEqual(self.splunk.port, SPLUNK_PORT)
+        self.assertEqual(self.splunk.username, SPLUNK_USERNAME)
+        self.assertEqual(self.splunk.password, SPLUNK_PASSWORD)
+        self.assertEqual(self.splunk.index, SPLUNK_INDEX)
+


### PR DESCRIPTION
Due to issues with the Splunk SDK for Python, I have rewritten the Splunk handler to use the requests library to send a POST request to the proper Splunk endpoint.

I will make another PR next to add tests when I get that figured out.