### PR TITLE
Overhaul SplunkHandler to use HTTP Event Collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![Code Climate](https://img.shields.io/codeclimate/github/zach-taylor/splunk_handler.svg?style=flat-square)](https://codeclimate.com/github/zach-taylor/splunk_handler)
 [![PyPI](https://img.shields.io/pypi/v/splunk_handler.svg?style=flat-square)](https://pypi.python.org/pypi/splunk_handler)
 
+**Splunk Handler is a Python Logger for sending logged events to an installation of Splunk Enterprise.**
+
+*This logger requires the destination Splunk Enterprise server to have enabled and configured the [Splunk HTTP Event Collector](http://dev.splunk.com/view/event-collector/SP-CAAAE6M).*
+
 ## Installation
 
 Pip:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name = 'splunk_handler',
-    version = '1.1.3',
+    version = '2.0.0',
     license = 'MIT License',
     description = 'A Python logging handler that sends your logs to Splunk',
     long_description = open('README.md').read(),

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -95,7 +95,7 @@ class SplunkHandler(logging.Handler):
             'event': self.format(record),
         }
 
-        return json.dumps(params)
+        return json.dumps(params, sort_keys=True)
 
     def _splunk_worker(self):
         queue_empty = True

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -43,6 +43,7 @@ class SplunkHandler(logging.Handler):
         self.log_payload = ""
         self.SIGTERM = False  # 'True' if application requested exit
         self.timer = None
+        self.testing = False  # Used for slightly altering logic during unit testing
         # It is possible to get 'behind' and never catch up, so we limit the queue size
         self.queue = Queue(maxsize=queue_size)
 
@@ -80,8 +81,12 @@ class SplunkHandler(logging.Handler):
         else:
             source = self.source
 
+        current_time = time.time()
+        if self.testing:
+            current_time = None
+
         params = {
-            'time': time.time(),
+            'time': current_time,
             'host': self.hostname,
             'index': self.index,
             'source': source,

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -1,30 +1,50 @@
+import atexit
+import json
 import logging
 import socket
+import sys
+import time
 import traceback
 
-from threading import Thread
+from threading import Timer
 
 import requests
 
+is_py2 = sys.version[0] == '2'
+if is_py2:
+    from Queue import Queue, Full, Empty
+else:
+    from queue import Queue, Full, Empty
 
 class SplunkHandler(logging.Handler):
     """
     A logging handler to send events to a Splunk Enterprise instance
+    running the Splunk HTTP Event Collector.
     """
+    instances = []  # For keeping track of running class instances
 
-    def __init__(self, host, port, username, password, index,
-                 hostname=None, source=None, sourcetype='text', verify=True):
+    def __init__(self, host, port, token, index,
+                 hostname=None, source=None, sourcetype='text',
+                 verify=True, timeout=60, flush_interval=15.0,
+                 queue_size=5000):
 
+        SplunkHandler.instances.append(self)
         logging.Handler.__init__(self)
 
         self.host = host
         self.port = port
-        self.username = username
-        self.password = password
+        self.token = token
         self.index = index
         self.source = source
         self.sourcetype = sourcetype
         self.verify = verify
+        self.timeout = timeout
+        self.flush_interval = flush_interval
+        self.log_payload = ""
+        self.SIGTERM = False  # 'True' if application requested exit
+        self.timer = None
+        # It is possible to get 'behind' and never catch up, so we limit the queue size
+        self.queue = Queue(maxsize=queue_size)
 
         if hostname is None:
             self.hostname = socket.gethostname()
@@ -41,45 +61,97 @@ class SplunkHandler(logging.Handler):
         if not self.verify:
             requests.packages.urllib3.disable_warnings()
 
+        # Start a worker thread responsible for sending logs
+        self.timer = Timer(self.flush_interval, self._splunk_worker)
+        self.timer.daemon = True  # Auto-kill thread if main process exits
+        self.timer.start()
+
     def emit(self, record):
-
-        thread = Thread(target=self._async_emit, args=(record, ))
-
-        thread.start()
-
-    def _async_emit(self, record):
-
+        record = self.format_record(record)
         try:
+            # Put log message into queue; worker thread will pick up
+            self.queue.put_nowait(record)
+        except Full:
+            print("Log queue full; log data will be dropped.")
 
-            if self.source is None:
-                source = record.pathname
-            else:
-                source = self.source
+    def format_record(self, record):
+        if self.source is None:
+            source = record.pathname
+        else:
+            source = self.source
 
-            params = {
-                'host': self.hostname,
-                'index': self.index,
-                'source': source,
-                'sourcetype': self.sourcetype
-            }
-            url = 'https://%s:%s/services/receivers/simple' % (self.host, self.port)
-            payload = self.format(record)
-            auth = (self.username, self.password)
+        params = {
+            'time': time.time(),
+            'host': self.hostname,
+            'index': self.index,
+            'source': source,
+            'sourcetype': self.sourcetype,
+            'event': self.format(record),
+        }
 
-            r = requests.post(
-                url,
-                auth=auth,
-                data=payload,
-                params=params,
-                verify=self.verify
-            )
+        return json.dumps(params)
 
-            r.close()
+    def _splunk_worker(self):
+        queue_empty = True
 
-        except Exception as e:
+        # Pull everything off the queue.
+        while not self.queue.empty():
             try:
-                print(traceback.format_exc())
-                print("Exception in Splunk logging handler: %s" % str(e))
-            except:
+                item = self.queue.get(block=False)
+                self.log_payload = self.log_payload + item
+                self.queue.task_done()
+            except Empty:
                 pass
 
+            # If the payload is getting very long, stop reading and send immediately.
+            if not self.SIGTERM and len(self.log_payload) >= 524288:  # 50MB
+                queue_empty = False
+                break
+
+        if self.log_payload:
+            url = 'https://%s:%s/services/collector' % (self.host, self.port)
+
+            try:
+                r = requests.post(
+                    url,
+                    data=self.log_payload,
+                    headers={'Authorization': "Splunk %s" % self.token},
+                    verify=self.verify,
+                    timeout=self.timeout,
+                )
+                r.raise_for_status()  # Throws exception for 4xx/5xx status
+
+            except Exception as e:
+                try:
+                    print(traceback.format_exc())
+                    print("Exception in Splunk logging handler: %s" % str(e))
+                except:
+                    pass
+
+            self.log_payload = ""
+
+        # Restart the timer
+        timer_interval = self.flush_interval
+        if not self.SIGTERM:
+            if not queue_empty:
+                timer_interval = 1.0  # Start up again right away if queue was not cleared
+
+            self.timer = Timer(timer_interval, self._splunk_worker)
+            self.timer.daemon = True  # Auto-kill thread if main process exits
+            self.timer.start()
+
+    def shutdown(self):
+        self.SIGTERM = True
+        self.timer.cancel()  # Cancels the scheduled Timer, allows exit immediatley
+
+        # Send the remaining items that might be sitting in queue.
+        self._splunk_worker()
+
+    # Called when application exit imminent (main thread ended / got kill signal)
+    @atexit.register
+    def catch_exit():
+        for instance in SplunkHandler.instances:
+            try:
+                instance.shutdown()
+            except:
+                pass

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -16,6 +16,7 @@ if is_py2:
 else:
     from queue import Queue, Full, Empty
 
+
 class SplunkHandler(logging.Handler):
     """
     A logging handler to send events to a Splunk Enterprise instance

--- a/tests/test_splunk_handler.py
+++ b/tests/test_splunk_handler.py
@@ -5,31 +5,50 @@ import mock
 
 from splunk_handler import SplunkHandler
 
-SPLUNK_HOST = 'splunk.example.com'
-SPLUNK_PORT = '8089'
-SPLUNK_USERNAME = 'admin'
-SPLUNK_PASSWORD = 'password'
-SPLUNK_INDEX = 'main'
-SPLUNK_HOSTNAME = 'localhost'
-SPLUNK_SOURCE = 'test'
-SPLUNK_SOURCETYPE = 'test'
+# These are intentionally different than the kwarg defaults
+SPLUNK_HOST = 'splunk-server.example.com'
+SPLUNK_PORT = 1234
+SPLUNK_TOKEN = '851A5E58-4EF1-7291-F947-F614A76ACB21'
+SPLUNK_INDEX = 'test_index'
+SPLUNK_HOSTNAME = 'test_host'
+SPLUNK_SOURCE = 'test_source'
+SPLUNK_SOURCETYPE = 'test_sourcetype'
 SPLUNK_VERIFY = False
+SPLUNK_TIMEOUT = 27
+SPLUNK_FLUSH_INTERVAL = 5.0
+SPLUNK_QUEUE_SIZE = 1111
 
-RECEIVER_URL = 'https://%s:%s/services/receivers/simple' % (SPLUNK_HOST, SPLUNK_PORT)
+RECEIVER_URL = 'https://%s:%s/services/collector' % (SPLUNK_HOST, SPLUNK_PORT)
+
+
+def mock_response(fixture=None, status=200):
+    response = mock.Mock()
+    if fixture is None:
+        response.text = ''
+    elif isinstance(fixture, dict):
+        response.text = str(fixture)
+    else:
+        response.text = load_fixture(fixture)
+    response.status_code = status
+    return response
+
 
 class TestSplunkHandler(unittest.TestCase):
     def setUp(self):
         self.splunk = SplunkHandler(
             host=SPLUNK_HOST,
             port=SPLUNK_PORT,
-            username=SPLUNK_USERNAME,
-            password=SPLUNK_PASSWORD,
+            token=SPLUNK_TOKEN,
             index=SPLUNK_INDEX,
             hostname=SPLUNK_HOSTNAME,
             source=SPLUNK_SOURCE,
             sourcetype=SPLUNK_SOURCETYPE,
-            verify=SPLUNK_VERIFY
+            verify=SPLUNK_VERIFY,
+            timeout=SPLUNK_TIMEOUT,
+            flush_interval=SPLUNK_FLUSH_INTERVAL,
+            queue_size=SPLUNK_QUEUE_SIZE,
         )
+        self.splunk.testing = True
 
     def tearDown(self):
         self.splunk = None
@@ -40,45 +59,35 @@ class TestSplunkHandler(unittest.TestCase):
         self.assertIsInstance(self.splunk, logging.Handler)
         self.assertEqual(self.splunk.host, SPLUNK_HOST)
         self.assertEqual(self.splunk.port, SPLUNK_PORT)
-        self.assertEqual(self.splunk.username, SPLUNK_USERNAME)
-        self.assertEqual(self.splunk.password, SPLUNK_PASSWORD)
+        self.assertEqual(self.splunk.token, SPLUNK_TOKEN)
         self.assertEqual(self.splunk.index, SPLUNK_INDEX)
         self.assertEqual(self.splunk.hostname, SPLUNK_HOSTNAME)
         self.assertEqual(self.splunk.source, SPLUNK_SOURCE)
         self.assertEqual(self.splunk.sourcetype, SPLUNK_SOURCETYPE)
         self.assertEqual(self.splunk.verify, SPLUNK_VERIFY)
+        self.assertEqual(self.splunk.timeout, SPLUNK_TIMEOUT)
+        self.assertEqual(self.splunk.flush_interval, SPLUNK_FLUSH_INTERVAL)
+        self.assertEqual(self.splunk.queue.maxsize, SPLUNK_QUEUE_SIZE)
 
         self.assertFalse(logging.getLogger('requests').propagate)
         self.assertFalse(logging.getLogger('splunk_handler').propagate)
 
 
-    @mock.patch('splunk_handler.Thread')
-    def test_emit(self, thread):
-        self.splunk.emit('hello')
-
-        self.assertEqual(
-            mock.call(target=self.splunk._async_emit, args=('hello',)),
-            thread.mock_calls[0]
-        )
-        thread.return_value.start.assert_called_once_with()
-
-    @mock.patch('splunk_handler.requests.post')
-    def test_async_emit(self, post):
+    @mock.patch('splunk_handler.requests')
+    def test_splunk_worker(self, requests):
         log = logging.getLogger('test')
         log.addHandler(self.splunk)
         log.warning('hello!')
 
-        post.assert_called_once_with(
+        self.splunk.timer.join() # Have to wait for the timer to exec
+
+        expected_output = '{"index": "%s", "sourcetype": "%s", "source": "%s", "host": "%s", "time": null, "event": "hello!"}' % \
+                          (SPLUNK_INDEX, SPLUNK_SOURCETYPE, SPLUNK_SOURCE, SPLUNK_HOSTNAME)
+        requests.post.return_value = mock_response()
+        requests.post.assert_called_once_with(
             RECEIVER_URL,
-            auth=(SPLUNK_USERNAME, SPLUNK_PASSWORD),
-            data='hello!',
-            params={
-                'host': SPLUNK_HOSTNAME,
-                'index': SPLUNK_INDEX,
-                'source': SPLUNK_SOURCE,
-                'sourcetype': SPLUNK_SOURCETYPE
-            },
-            verify=SPLUNK_VERIFY
+            verify=SPLUNK_VERIFY,
+            data=expected_output,
+            timeout=SPLUNK_TIMEOUT,
+            headers={'Authorization': "Splunk %s" % SPLUNK_TOKEN},
         )
-
-

--- a/tests/test_splunk_handler.py
+++ b/tests/test_splunk_handler.py
@@ -81,8 +81,8 @@ class TestSplunkHandler(unittest.TestCase):
 
         self.splunk.timer.join() # Have to wait for the timer to exec
 
-        expected_output = '{"index": "%s", "sourcetype": "%s", "source": "%s", "host": "%s", "time": null, "event": "hello!"}' % \
-                          (SPLUNK_INDEX, SPLUNK_SOURCETYPE, SPLUNK_SOURCE, SPLUNK_HOSTNAME)
+        expected_output = '{"event": "hello!", "host": "%s", "index": "%s", "source": "%s", "sourcetype": "%s", "time": null}' % \
+                          (SPLUNK_HOSTNAME, SPLUNK_INDEX, SPLUNK_SOURCE, SPLUNK_SOURCETYPE)
         requests.post.return_value = mock_response()
         requests.post.assert_called_once_with(
             RECEIVER_URL,


### PR DESCRIPTION
## Problem
In the time since the initial release of this package, Splunk has released the HTTP Event Collector, a RESTful mechanism for taking in webhook-type log data.  This new Splunk mechanism supports features like batch sending, event time declaration, and most importantly, relies on a single shared secret token for authentication, instead of the old method of requiring login credentials for interactive user accounts.

Another issue that needed to be addressed was the spin-up of a new Thread for each log message.  On moderate-to-high-traffic *nix servers, the OS limit on open 'files' could very quickly be reached, causing the server itself to have downtime.

## Solution
I have done the requisite work to migrate all REST traffic to the new HTTP Event Collector interface.  In addition, this PR adds a message queuing mechanism (*_disclaimer: it does not retry on failure_) with an adjustable limit.  The logger attempts to batch and send everything in the queue at once, unless the payload size will exceed 50MB and the main application is not actively shutting down.  If the 50MB limit is reached, that portion of the batched payload is sent immediately, and the queue resumes work at its previous position.  The 50MB limit was derived from my personal testing against an instance of Splunk, and is by no means a hard limit on the Splunk side.

This is an extremely breaking change.  I have suggested making this the 2.0.0 release of this package.