### PR TITLE
Allow callers to force flush and exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@
 
 *This logger requires the destination Splunk Enterprise server to have enabled and configured the [Splunk HTTP Event Collector](http://dev.splunk.com/view/event-collector/SP-CAAAE6M).*
 
+## A Note on Using with AWS Lambda
+
+[AWS Lambda](https://aws.amazon.com/lambda/) has a custom implementation of Python Threading, and does not signal when the main thread exits. Because of this, it is possible to have Lambda halt execution while logs are still being processed. To ensure that execution does not terminate prematurely, Lambda users will be required to invoke splunk_handler.perform_exit directly as the very last call in the Lambda handler, which will block the main thread from exiting until all logs have processed.
+~~~python
+from splunk_handler import perform_exit
+
+def lambda_handler(event, context):
+    do_work()
+    perform_exit()  # Flush logs and shut down processing
+~~~
+
+
 ## Installation
 
 Pip:
@@ -119,4 +131,3 @@ Feel free to contribute an issue or pull request:
 ## License
 
 This project is licensed under the terms of the [MIT license](http://opensource.org/licenses/MIT).
-

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name = 'splunk_handler',
-    version = '2.0.1',
+    version = '2.0.2',
     license = 'MIT License',
     description = 'A Python logging handler that sends your logs to Splunk',
     long_description = open('README.md').read(),

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -17,6 +17,7 @@ else:
     from queue import Queue, Full, Empty
 
 instances = []  # For keeping track of running class instances
+
 # Called when application exit imminent (main thread ended / got kill signal)
 @atexit.register
 def perform_exit():
@@ -36,6 +37,7 @@ class SplunkHandler(logging.Handler):
                  verify=True, timeout=60, flush_interval=15.0,
                  queue_size=5000, debug=False):
 
+        global instances
         instances.append(self)
         logging.Handler.__init__(self)
 


### PR DESCRIPTION
## Problem
AWS Lambda straight-up breaks Threading and exit signaling and can exit before logs have flushed.  We have to deal with that :(

## Solution
Implemented a public function at the module level which allows a caller to flush all running instances of SplunkHandler.  See README diff for more information.

@zach-taylor sorry for the higher-ish level of activity over the last two days.  PR #14 was required to finally understand and solve this issue.