### PR TITLE
Support Python close() statement

### DIFF
--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -195,7 +195,15 @@ class SplunkHandler(logging.Handler):
             self.timer.start()
             self.write_log("Timer thread scheduled", is_debug=True)
 
+    def close(self):
+        self.shutdown()
+        logging.Handler.close(self)
+
     def shutdown(self):
+        # Only initiate shutdown once
+        if self.SIGTERM:
+            return
+
         self.write_log("Immediate shutdown requested", is_debug=True)
         self.SIGTERM = True
         self.timer.cancel()  # Cancels the scheduled Timer, allows exit immediatley


### PR DESCRIPTION
## Problem
Python logging handlers should really handle the close() statement properly, and ours did not.

## Solution
Added close() statement handling, which invokes existing shutdown logic.  Minor change, we don't need to release yet (I've got retry support inbound soon anyway).