### PR TITLE
Built-in, throttled, and configurable retry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Example:
         #flush_interval=15.0, # send batches of log statements every n seconds, defaults to 15.0
         #queue_size=5000, # a throttle to prevent resource overconsumption, defaults to 5000
         #debug=False, # turn on debug mode; prints module activity to stdout, defaults to False
+        #retry_count=5, # Number of retry attempts on a failed/erroring connection, defaults to 5
+        #retry_backoff=2.0,  # Backoff factor, default options will retry for 1 min, defaults to 2.0
     )
 
     logging.getLogger('').addHandler(splunk)
@@ -106,6 +108,13 @@ LOGGING = {
 Then, do `logging.config.dictConfig(LOGGING)` to configure your logging.
 
 Note: I included a configuration for the JSON formatter mentioned above.
+
+## Retry Logic
+
+This library uses the built-in retry logic from urllib3 (a retry
+counter and a backoff factor). Should the defaults not be desireable,
+you can find more information about how to best configure these
+settings in the [urllib3 documentation](https://github.com/kennethreitz/requests/blob/b2289cd2d5d21bd31cf4a818a4e0ff6951b2317a/requests/packages/urllib3/util/retry.py#L104).
 
 ## Contributing
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name = 'splunk_handler',
-    version = '2.0.1',
+    version = '2.0.3',
     license = 'MIT License',
     description = 'A Python logging handler that sends your logs to Splunk',
     long_description = open('README.md').read(),

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -182,7 +182,6 @@ class SplunkHandler(logging.Handler):
 
             try:
                 self.write_log("Sending payload: " + self.log_payload, is_debug=True)
-
                 r = self.session.post(
                     url,
                     data=self.log_payload,

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -10,7 +10,6 @@ from threading import Timer
 
 import requests
 from requests.packages.urllib3.util.retry import Retry
-from requests.packages.urllib3 import PoolManager
 from requests.adapters import HTTPAdapter
 
 is_py2 = sys.version[0] == '2'


### PR DESCRIPTION
## Problem
This library is currently fire-once and forget, which may be undesirable.

## Solution
Added a Retry adapter with user-configurable parameters.  This adapter is throttled with an exponential back-off.  Out of the box, this mechanism will default to 5 attempts over a period of 1 minute.