### PR TITLE
Add force flush capabilities for AWS Lambda users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 
 ## A Note on Using with AWS Lambda
 
-[AWS Lambda](https://aws.amazon.com/lambda/) has a custom implementation of Python Threading, and does not signal when the main thread exits. Because of this, it is possible to have Lambda halt execution while logs are still being processed. To ensure that execution does not terminate prematurely, Lambda users will be required to invoke splunk_handler.perform_exit directly as the very last call in the Lambda handler, which will block the main thread from exiting until all logs have processed.
+[AWS Lambda](https://aws.amazon.com/lambda/) has a custom implementation of Python Threading, and does not signal when the main thread exits. Because of this, it is possible to have Lambda halt execution while logs are still being processed. To ensure that execution does not terminate prematurely, Lambda users will be required to invoke splunk_handler.force_flush directly as the very last call in the Lambda handler, which will block the main thread from exiting until all logs have processed.
 ~~~python
-from splunk_handler import perform_exit
+from splunk_handler import force_flush
 
 def lambda_handler(event, context):
     do_work()
-    perform_exit()  # Flush logs and shut down processing
+    force_flush()  # Flush logs in a blocking manner
 ~~~
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = 'splunk_handler',
-    version = '2.0.4',
+    version = '2.0.5',
     license = 'MIT License',
     description = 'A Python logging handler that sends your logs to Splunk',
     long_description = open('README.md').read(),

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -29,6 +29,13 @@ def perform_exit():
         except:
             pass
 
+def force_flush():
+    for instance in instances:
+        try:
+            instance.force_flush()
+        except:
+            pass
+
 class SplunkHandler(logging.Handler):
     """
     A logging handler to send events to a Splunk Enterprise instance
@@ -160,6 +167,10 @@ class SplunkHandler(logging.Handler):
         self.write_log("_splunk_worker() called", is_debug=True)
 
         if self.flush_interval > 0:
+            # Stop the timer. Happens automatically if this is called
+            # via the timer, does not if invoked by force_flush()
+            self.timer.cancel()
+
             # Pull everything off the queue.
             queue_empty = True
             while not self.queue.empty():
@@ -228,6 +239,10 @@ class SplunkHandler(logging.Handler):
     def close(self):
         self.shutdown()
         logging.Handler.close(self)
+
+    def force_flush(self):
+        self.write_log("Force flush requested", is_debug=True)
+        self._splunk_worker()
 
     def shutdown(self):
         self.write_log("Immediate shutdown requested", is_debug=True)


### PR DESCRIPTION
I had previously added perform_exit() for AWS Lambda users to be able to clear out their logs before Lambda initiates shutdown, however in testing I've found that Lambda actually keeps entire classes around, in memory, even when jobs are not active.  This means that if you call perform_exit() manually, you actually kill your instance of the splunk_handler for no reason and cannot use it again until AWS recycles your function.  Not cool.

So instead, adding the option for users to call `force_flush()`, which will send all logs in a blocking manner.

@zach-taylor 