### PR TITLE
Suppress urllib3 logs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='splunk_handler',
-    version='2.0.5',
+    version='2.0.6',
     license='MIT License',
     description='A Python logging handler that sends your logs to Splunk',
     long_description=open('README.md').read(),

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -85,6 +85,7 @@ class SplunkHandler(logging.Handler):
 
         # prevent infinite recursion by silencing requests and urllib3 loggers
         logging.getLogger('requests').propagate = False
+        logging.getLogger('urllib3').propagate = False
 
         # and do the same for ourselves
         logging.getLogger(__name__).propagate = False


### PR DESCRIPTION
If logging mode is debug on the root logger, urllib3 will cause recursive log writes forever.  I thought that suppressing the requests lib logger would handle urllib3 as well, but I was not correct.

@zach-taylor for your review