### PR TITLE
Add method_whitelist=False to fix retry on POST

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='splunk_handler',
-    version='2.0.5',
+    version='2.0.7',
     license='MIT License',
     description='A Python logging handler that sends your logs to Splunk',
     long_description=open('README.md').read(),

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -97,6 +97,7 @@ class SplunkHandler(logging.Handler):
         self.write_debug_log("Preparing to create a Requests session")
         retry = Retry(total=self.retry_count,
                       backoff_factor=self.retry_backoff,
+                      method_whitelist=False,  # Retry for any HTTP verb
                       status_forcelist=[500, 502, 503, 504])
         self.session.mount('https://', HTTPAdapter(max_retries=retry))
 


### PR DESCRIPTION
Well, this is embarrassing. 

I have discovered that urllib3 Retry by default does not actually retry if the HTTP verb is a POST.  So that part has never worked upon failures.

@zach-taylor for your review.