### PR TITLE
reduce time to create payload

### DIFF
--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -128,7 +128,7 @@ class SplunkHandler(logging.Handler):
 
         self.write_debug_log("Writing record to log queue")
         # Put log message into queue; worker thread will pick up
-        if self.cur_queue_size < self.max_queue_size:
+        if not self.max_queue_size or self.cur_queue_size < self.max_queue_size:
             self.queue.append(record)
             self.cur_queue_size += 1
         else:

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -2,21 +2,13 @@ import atexit
 import json
 import logging
 import socket
-import sys
 import time
 import traceback
-
 from threading import Timer
 
 import requests
-from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
-
-is_py2 = sys.version[0] == '2'
-if is_py2:
-    from Queue import Queue, Full, Empty
-else:
-    from queue import Queue, Full, Empty
+from requests.packages.urllib3.util.retry import Retry
 
 instances = []  # For keeping track of running class instances
 
@@ -44,6 +36,7 @@ class SplunkHandler(logging.Handler):
     A logging handler to send events to a Splunk Enterprise instance
     running the Splunk HTTP Event Collector.
     """
+
     def __init__(self, host, port, token, index,
                  hostname=None, source=None, sourcetype='text',
                  verify=True, timeout=60, flush_interval=15.0,
@@ -69,7 +62,9 @@ class SplunkHandler(logging.Handler):
         self.timer = None
         self.testing = False  # Used for slightly altering logic during unit testing
         # It is possible to get 'behind' and never catch up, so we limit the queue size
-        self.queue = Queue(maxsize=queue_size)
+        self.queue = list()
+        self.max_queue_size = queue_size
+        self.cur_queue_size = 0
         self.debug = debug
         self.session = requests.Session()
         self.retry_count = retry_count
@@ -97,20 +92,20 @@ class SplunkHandler(logging.Handler):
         # disable all warnings from urllib3 package
         if not self.verify:
             requests.packages.urllib3.disable_warnings()
-       
+
         if self.verify and self.protocol == 'http':
             print("[SplunkHandler DEBUG] " + 'cannot use SSL Verify and unsecure connection')
-       
+
         if self.proxies is not None:
             self.session.proxies = self.proxies
-           
+
         # Set up automatic retry with back-off
         self.write_debug_log("Preparing to create a Requests session")
         retry = Retry(total=self.retry_count,
                       backoff_factor=self.retry_backoff,
                       method_whitelist=False,  # Retry for any HTTP verb
                       status_forcelist=[500, 502, 503, 504])
-        self.session.mount(self.protocol+'://', HTTPAdapter(max_retries=retry))
+        self.session.mount(self.protocol + '://', HTTPAdapter(max_retries=retry))
 
         self.start_worker_thread()
 
@@ -126,16 +121,18 @@ class SplunkHandler(logging.Handler):
             self.write_log(traceback.format_exc())
             return
 
-        if self.flush_interval > 0:
-            try:
-                self.write_debug_log("Writing record to log queue")
-                # Put log message into queue; worker thread will pick up
-                self.queue.put_nowait(record)
-            except Full:
-                self.write_log("Log queue full; log data will be dropped.")
-        else:
+        if self.flush_interval <= 0:
             # Flush log immediately; is blocking call
             self._splunk_worker(payload=record)
+            return
+
+        self.write_debug_log("Writing record to log queue")
+        # Put log message into queue; worker thread will pick up
+        if self.cur_queue_size < self.max_queue_size:
+            self.queue.append(record)
+            self.cur_queue_size += 1
+        else:
+            self.write_log("Log queue full; log data will be dropped.")
 
     def close(self):
         self.shutdown()
@@ -244,7 +241,8 @@ class SplunkHandler(logging.Handler):
             else:
                 if not queue_is_empty:
                     self.write_debug_log("Queue not empty, scheduling timer to run immediately")
-                    timer_interval = 1.0  # Start up again right away if queue was not cleared
+                    # Start up again right away if queue was not cleared
+                    timer_interval = min(1.0, self.flush_interval / 2)
 
                 self.write_debug_log("Resetting timer thread")
                 self.timer = Timer(timer_interval, self._splunk_worker)
@@ -253,22 +251,20 @@ class SplunkHandler(logging.Handler):
                 self.write_debug_log("Timer thread scheduled")
 
     def empty_queue(self):
-        while not self.queue.empty():
-            self.write_debug_log("Recursing through queue")
-            try:
-                item = self.queue.get(block=False)
-                self.log_payload = self.log_payload + item
-                self.queue.task_done()
-                self.write_debug_log("Queue task completed")
-            except Empty:
-                self.write_debug_log("Queue was empty")
+        if len(self.queue) == 0:
+            self.write_debug_log("Queue was empty")
+            return True
 
-            # If the payload is getting very long, stop reading and send immediately.
-            if not self.SIGTERM and len(self.log_payload) >= 524288:  # 50MB
-                self.write_debug_log("Payload maximum size exceeded, sending immediately")
-                return False
+        self.write_debug_log("Recursing through queue")
+        # without looking at each item, estimate how many can fit in 50 MB
+        apprx_size_base = len(self.queue[0])
+        # dont count more than what is in queue to ensure the same number as pulled are deleted
+        count = min(int(524288 / apprx_size_base), len(self.queue))
+        self.log_payload += ''.join(self.queue[:count])
+        del self.queue[:count]
+        self.write_debug_log("Queue task completed")
 
-        return True
+        return len(self.queue) > 0
 
     def force_flush(self):
         self.write_debug_log("Force flush requested")

--- a/tests/test_splunk_handler.py
+++ b/tests/test_splunk_handler.py
@@ -61,7 +61,7 @@ class TestSplunkHandler(unittest.TestCase):
         self.assertEqual(self.splunk.verify, SPLUNK_VERIFY)
         self.assertEqual(self.splunk.timeout, SPLUNK_TIMEOUT)
         self.assertEqual(self.splunk.flush_interval, SPLUNK_FLUSH_INTERVAL)
-        self.assertEqual(self.splunk.queue.maxsize, SPLUNK_QUEUE_SIZE)
+        self.assertEqual(self.splunk.max_queue_size, SPLUNK_QUEUE_SIZE)
         self.assertEqual(self.splunk.debug, SPLUNK_DEBUG)
         self.assertEqual(self.splunk.retry_count, SPLUNK_RETRY_COUNT)
         self.assertEqual(self.splunk.retry_backoff, SPLUNK_RETRY_BACKOFF)


### PR DESCRIPTION
Iterating through a queue and appending each item to a string results in many memory rewrites, which is time consuming. Using a list and splicing, reduce the time to build the payload

@sullivanmatt 