### PR TITLE
fix dup log race condition on shutdown

### DIFF
--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -249,6 +249,7 @@ class SplunkHandler(logging.Handler):
 
         if not payload:
             payload = self.log_payload
+            self.log_payload = ""
 
         if payload:
             self.write_debug_log("Payload available for sending")
@@ -274,7 +275,6 @@ class SplunkHandler(logging.Handler):
                     self.write_debug_log("Exception encountered," +
                                          "but traceback could not be formatted")
 
-            self.log_payload = ""
         else:
             self.write_debug_log("Timer thread executed but no payload was available to send")
 
@@ -338,14 +338,9 @@ class SplunkHandler(logging.Handler):
 
     def wait_until_empty(self):
         self.write_debug_log("Waiting until queue empty")
-        flush_interval = self.flush_interval
-        self.flush_interval = .5
-
         while len(self.queue) > 0:
             self.write_debug_log("Current queue size: " + str(len(self.queue)))
-            time.sleep(.5)
-
-        self.flush_interval = flush_interval
+            time.sleep(self.alt_flush_interval)
 
     @property
     def alt_flush_interval(self):

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -60,7 +60,7 @@ class SplunkHandler(logging.Handler):
             index (str): Splunk index to write to
             allow_overrides (bool): Whether to look for _<param> in log data (ex: _index)
             debug (bool): Whether to print debug console messages
-            flush_interval (float): How often to push events to splunk host in microseconds
+            flush_interval (float): How often to push events to splunk host in seconds
             force_keep_ahead (bool): Sleep instead of dropping logs when queue fills
             hostname (str): The Splunk Enterprise hostname
             protocol (str): The web protocol to use


### PR DESCRIPTION
#### Problem
`wait_until_empty` allows the code to wait until the queue has been emptied. However, there is still a race condition between the response from the Splunk server and the execution of shutdown.

Instance `shutdown()` calls `_splunk_worker()`, which will call `empty_queue()`. If the connection to splunk is still open from the Timer call that emptied the queue, the Timer thread will not have yet cleared `self.log_payload`, which can result in the shutdown resending the payload, because `empty_queue()` only appends to `self.log_payload`.

#### Solution
There are multiple options:

1. Have `_splunk_worker()` check the queue size. This was not done as it doesnt align with the option to send a payload as an arg to the function
2. Have `shutdown()` send the payload in the `_splunk_worker()` call.
3. Clear `self.log_payload` as soon as it is read instead of after it is received by splunk. The payload is thrown away regardless of error already, so this seemed like the best option.


Additionally removed the `flush_interval` adjustment made in `wait_until_empty()` as the timer is already adjusted in `_splunk_worker()` when there is content in the queue after completing a call to splunk

@zach-taylor 