### PR TITLE
Use services/collector/event endpoint for splunk

### DIFF
--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -106,7 +106,7 @@ class SplunkHandler(logging.Handler):
         self.record_format = record_format
         self.processing_payload = False
         if not url:
-            self.url = '%s://%s:%s/services/collector' % (self.protocol, self.host, self.port)
+            self.url = '%s://%s:%s/services/collector/event' % (self.protocol, self.host, self.port)
         else:
             self.url = url
 

--- a/tests/test_splunk_handler.py
+++ b/tests/test_splunk_handler.py
@@ -23,7 +23,7 @@ SPLUNK_DEBUG = False
 SPLUNK_RETRY_COUNT = 1
 SPLUNK_RETRY_BACKOFF = 0.1
 
-RECEIVER_URL = 'https://%s:%s/services/collector' % (SPLUNK_HOST, SPLUNK_PORT)
+RECEIVER_URL = 'https://%s:%s/services/collector/event' % (SPLUNK_HOST, SPLUNK_PORT)
 
 
 class TestSplunkHandler(unittest.TestCase):


### PR DESCRIPTION
As per the example here with curl:
https://docs.splunk.com/Documentation/Splunk/8.1.3/Data/UsetheHTTPEventCollector
Use the services/collector/event endpoint