### PR TITLE
Fix queued event >50MB causes hang

### DIFF
--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -310,7 +310,7 @@ class SplunkHandler(logging.Handler):
             # without looking at each item, estimate how many can fit in 50 MB
             apprx_size_base = len(self.queue[0])
             # dont count more than what is in queue to ensure the same number as pulled are deleted
-            count = min(int(524288 / apprx_size_base), len(self.queue))
+            count = max(min(int(524288 / apprx_size_base), len(self.queue)), 1)
             self.log_payload += ''.join(self.queue[:count])
             del self.queue[:count]
         self.write_debug_log("Queue task completed")

--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -309,8 +309,9 @@ class SplunkHandler(logging.Handler):
         else:
             # without looking at each item, estimate how many can fit in 50 MB
             apprx_size_base = len(self.queue[0])
+            # dont eval max/event size ration as less than 1
             # dont count more than what is in queue to ensure the same number as pulled are deleted
-            count = max(min(int(524288 / apprx_size_base), len(self.queue)), 1)
+            count = min(max(int(524288 / apprx_size_base), 1), len(self.queue))
             self.log_payload += ''.join(self.queue[:count])
             del self.queue[:count]
         self.write_debug_log("Queue task completed")


### PR DESCRIPTION
If the first item in the queue is larger than 524288, then count becomes 0. This results in a perpetually empty payload, which prevents additional logs from being sent to Splunk

@zach-taylor