### PR TITLE
Fix empty_queue returns True when not empty

### DIFF
--- a/splunk_handler/__init__.py
+++ b/splunk_handler/__init__.py
@@ -316,7 +316,7 @@ class SplunkHandler(logging.Handler):
             del self.queue[:count]
         self.write_debug_log("Queue task completed")
 
-        return len(self.queue) > 0
+        return len(self.queue) == 0
 
     def force_flush(self):
         self.write_debug_log("Force flush requested")


### PR DESCRIPTION
## Problem
When called with a non-empty queue, `empty_queue` erroneously returns `False` when the queue is emptied as a result of its call, and `True` otherwise.

## Solution
Return `len(queue) == 0` (True when queue is empty) instead of `len(queue) > 0` (True when queue not empty)