### PR TITLE
add additional headers to splunk request

### DIFF
--- a/tests/test_splunk_handler.py
+++ b/tests/test_splunk_handler.py
@@ -22,6 +22,7 @@ SPLUNK_QUEUE_SIZE = 1111
 SPLUNK_DEBUG = False
 SPLUNK_RETRY_COUNT = 1
 SPLUNK_RETRY_BACKOFF = 0.1
+SPLUNK_ADDITIONAL_HEADERS = {"test": "header"}
 
 RECEIVER_URL = 'https://%s:%s/services/collector/event' % (SPLUNK_HOST, SPLUNK_PORT)
 
@@ -45,6 +46,7 @@ class TestSplunkHandler(unittest.TestCase):
             debug=SPLUNK_DEBUG,
             retry_count=SPLUNK_RETRY_COUNT,
             retry_backoff=SPLUNK_RETRY_BACKOFF,
+            additional_headers=SPLUNK_ADDITIONAL_HEADERS,
         )
 
     def tearDown(self):
@@ -68,6 +70,7 @@ class TestSplunkHandler(unittest.TestCase):
         self.assertEqual(self.splunk.debug, SPLUNK_DEBUG)
         self.assertEqual(self.splunk.retry_count, SPLUNK_RETRY_COUNT)
         self.assertEqual(self.splunk.retry_backoff, SPLUNK_RETRY_BACKOFF)
+        self.assertTrue(self.splunk.additional_headers, SPLUNK_ADDITIONAL_HEADERS)
 
         self.assertFalse(logging.getLogger('requests').propagate)
         self.assertFalse(logging.getLogger('splunk_handler').propagate)
@@ -96,7 +99,7 @@ class TestSplunkHandler(unittest.TestCase):
             verify=SPLUNK_VERIFY,
             data=expected_output,
             timeout=SPLUNK_TIMEOUT,
-            headers={'Authorization': "Splunk %s" % SPLUNK_TOKEN},
+            headers={'Authorization': "Splunk %s" % SPLUNK_TOKEN, **SPLUNK_ADDITIONAL_HEADERS},
         )
 
     def test_splunk_worker_override(self):
@@ -123,7 +126,7 @@ class TestSplunkHandler(unittest.TestCase):
         self.mock_request.assert_called_once_with(
             RECEIVER_URL,
             data=expected_output,
-            headers={'Authorization': "Splunk %s" % SPLUNK_TOKEN},
+            headers={'Authorization': "Splunk %s" % SPLUNK_TOKEN, **SPLUNK_ADDITIONAL_HEADERS},
             verify=SPLUNK_VERIFY,
             timeout=SPLUNK_TIMEOUT
         )
@@ -184,7 +187,7 @@ class TestSplunkHandler(unittest.TestCase):
         self.mock_request.assert_has_calls([call(
             RECEIVER_URL,
             data=expected_output * 10,
-            headers={'Authorization': 'Splunk %s' % SPLUNK_TOKEN},
+            headers={'Authorization': "Splunk %s" % SPLUNK_TOKEN, **SPLUNK_ADDITIONAL_HEADERS},
             verify=SPLUNK_VERIFY,
             timeout=SPLUNK_TIMEOUT
         )] * 2, any_order=True)


### PR DESCRIPTION
Add functionality to send custom header in Splunk requests. My case is to add X-Splunk-Request-Channel. Description in [splunk docs](https://docs.splunk.com/Documentation/Splunk/9.1.0/Data/AboutHECIDXAck?_gl=1*1xorwnq*_ga*NjA0OTQyNzM1LjE3MDY3MDEzMDg.*_ga_GS7YF8S63Y*MTcxNTA3ODI0NS4xNi4wLjE3MTUwNzkwMDMuNjAuMC4w*_ga_5EPM2P39FV*MTcxNTA3NzEwNC4xOC4xLjE3MTUwNzkwMDMuMC4wLjY4NDA4MTA2Mw..&_ga=2.62275244.1418240969.1715077105-604942735.1706701308).

@zach-taylor do I have any chances to see this PR merged or repo is frozen?